### PR TITLE
AccuweatherService

### DIFF
--- a/app/services/accuweather_service.rb
+++ b/app/services/accuweather_service.rb
@@ -1,0 +1,19 @@
+class AccuweatherService
+  def location_by_ip_address(ipv4_address)
+    parse_response('locations/v1/cities/ipaddress', q: ipv4_address)
+  end
+
+  private
+
+  def parse_response(url, params = {})
+    response = connection.get(url, params)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+  
+  def connection
+    Faraday.new('http://dataservice.accuweather.com') do |f|
+      f.params['apikey'] = ENV['ACCUWEATHER_API_KEY']
+      f.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/spec/services/accuweather_service_spec.rb
+++ b/spec/services/accuweather_service_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'AccuweatherService' do
+  describe 'instance methods' do
+    it '.location_by_ip_address' do
+      accuweather_service = AccuweatherService.new
+      ipv4_address = '73.14.137.32'
+
+      location = accuweather_service.location_by_ip_address(ipv4_address)
+
+      expect(location).to have_key(:Country)
+      expect(location).to have_key(:AdministrativeArea)
+      expect(location).to have_key(:TimeZone)
+      expect(location).to have_key(:GeoPosition)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an AccuweatherService, which is able query the AccuWeather API and retrieve a location from an IP address.

- Adds AccuweatherService#location_by_ip_address with spec
- Adds AccuweatherService private methods #connection and #parse_response