### PR TITLE
Fetch Location by IP Address

### DIFF
--- a/app/controllers/api/v1/location_by_ip_controller.rb
+++ b/app/controllers/api/v1/location_by_ip_controller.rb
@@ -1,7 +1,17 @@
 class Api::V1::LocationByIpController < ApplicationController
+  before_action :validate_ipv4_address, only: :index
+
   def index
     facade = LocationByIpFacade.new(params[:ip])
     location_serializer = LocationByIpSerializer.new(facade.location_info)
     render json: location_serializer.format_response
+  end
+
+  private
+
+  def validate_ipv4_address
+    if !params[:ip].match?(/\b(?:\d{1,3}\.){3}\d{1,3}\b/)
+      render json: { error: 'Please provide an address with valid IPv4 formatting.' }, status: 400
+    end
   end
 end

--- a/app/controllers/api/v1/location_by_ip_controller.rb
+++ b/app/controllers/api/v1/location_by_ip_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::LocationByIpController < ApplicationController
+  def index
+
+  end
+end

--- a/app/controllers/api/v1/location_by_ip_controller.rb
+++ b/app/controllers/api/v1/location_by_ip_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::LocationByIpController < ApplicationController
   def index
-
+    facade = LocationByIpFacade.new(params[:ip])
+    location_serializer = LocationByIpSerializer.new(facade.location_info)
+    render json: location_serializer.format_response
   end
 end

--- a/app/facades/location_by_ip_facade.rb
+++ b/app/facades/location_by_ip_facade.rb
@@ -1,0 +1,17 @@
+class LocationByIpFacade
+  def initialize(ipv4_address)
+    @ipv4_address = ipv4_address
+  end
+
+  def location_info
+    @location_info ||= accuweather_service.location_by_ip_address(ipv4_address)
+  end
+
+  private
+
+  attr_reader :ipv4_address
+
+  def accuweather_service
+    AccuweatherService.new
+  end
+end

--- a/app/serializers/location_by_ip_serializer.rb
+++ b/app/serializers/location_by_ip_serializer.rb
@@ -1,0 +1,28 @@
+class LocationByIpSerializer
+  def initialize(location_info)
+    @location_info = location_info
+  end
+
+  def format_response
+    {
+      Country: {
+        ID: location_info[:Key],
+        LocalizedName: location_info[:Country][:LocalizedName]
+      },
+      latitude: location_info[:GeoPosition][:Latitude],
+      longitude: location_info[:GeoPosition][:Longitude],
+      IsDaylightSaving: location_info[:TimeZone][:IsDaylightSaving],
+      processingCode: format_processing_code
+    }
+  end
+
+  private
+
+  attr_reader :location_info
+
+  def format_processing_code
+    "#{location_info[:Country][:LocalizedName]} - "\
+    "#{location_info[:AdministrativeArea][:LocalizedName]} - "\
+    "#{location_info[:LocalizedName]}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get 'locationByIp', to: 'location_by_ip#index'
+    end
+  end
 end

--- a/spec/requests/api/v1/location_by_ip_endpoint_spec.rb
+++ b/spec/requests/api/v1/location_by_ip_endpoint_spec.rb
@@ -18,4 +18,18 @@ RSpec.describe 'locationByIp endpoint', type: :request do
       expect(location_by_ip[:processingCode]).to eq('United States - Florida - Venice')
     end
   end
+
+  describe 'with an invalid IP address' do
+    it 'returns an error' do
+      ipv6_address = 'FE80:CD00:0000:0CDE:1257:0000:211E:729C'
+
+      get '/api/v1/locationByIp', params: { ip: ipv6_address }
+
+      error = JSON.parse(response.body, symbolize_names: true)[:error]
+
+      expect(response.status).to eq(400)
+
+      expect(error).to eq('Please provide an address with valid IPv4 formatting.')
+    end
+  end
 end

--- a/spec/requests/api/v1/location_by_ip_endpoint_spec.rb
+++ b/spec/requests/api/v1/location_by_ip_endpoint_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'locationByIp endpoint', type: :request do
+  describe 'with a valid IP address' do
+    it 'returns location information' do
+      ipv4_address = '73.14.137.32'
+
+      get '/api/v1/locationByIp', params: { ip: ipv4_address }
+
+      location_by_ip = JSON.parse(response.body, symbolize_names: true)
+      country = location_by_ip[:Country]
+
+      expect(response.status).to eq(200)
+
+      expect(location_by_ip[:latitude]).to be_within(0.1).of(27.1)
+      expect(location_by_ip[:longitude]).to be_within(0.1).of(-82.4)
+      expect(location_by_ip[:IsDaylightSaving]).to be(true || false)
+      expect(location_by_ip[:processingCode]).to eq('United States - Florida - Venice')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the `locationByIp` endpoint, which accepts a query parameter (ip=), and returns location information based on specified IP address.  The endpoint only accepts IPv4 formatted addresses, and will return a 400 error if an incorrectly formatted address is sent.

- Adds spec for `locationByIp` endpoint
- Adds `LocationByIpController#index`, and `#validate_ipv4_address` which occurs before the `index` action
- Adds LocationByIpFacade with #location_info
- Adds LocationByIpSerializer with #format_response

Potential additional edge cases:
- Valid IP addresses that return no data
- No query parameter sent at all