### PR TITLE
No IP Address Provided

### DIFF
--- a/app/controllers/api/v1/location_by_ip_controller.rb
+++ b/app/controllers/api/v1/location_by_ip_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::LocationByIpController < ApplicationController
-  before_action :validate_ipv4_address, only: :index
+  before_action :validate_ip_address, only: :index
 
   def index
     facade = LocationByIpFacade.new(params[:ip])
@@ -9,8 +9,10 @@ class Api::V1::LocationByIpController < ApplicationController
 
   private
 
-  def validate_ipv4_address
-    if !params[:ip].match?(/\b(?:\d{1,3}\.){3}\d{1,3}\b/)
+  def validate_ip_address
+    if params[:ip] == nil
+      render json: { error: 'Please provide an IP address as a query parameter.'}, status: 400
+    elsif !params[:ip].match?(/\b(?:\d{1,3}\.){3}\d{1,3}\b/)
       render json: { error: 'Please provide an address with valid IPv4 formatting.' }, status: 400
     end
   end

--- a/spec/requests/api/v1/location_by_ip_endpoint_spec.rb
+++ b/spec/requests/api/v1/location_by_ip_endpoint_spec.rb
@@ -19,8 +19,20 @@ RSpec.describe 'locationByIp endpoint', type: :request do
     end
   end
 
+  describe 'with a no IP address' do
+    it 'returns a 400 error' do
+      get '/api/v1/locationByIp'
+
+      error = JSON.parse(response.body, symbolize_names: true)[:error]
+
+      expect(response.status).to eq(400)
+
+      expect(error).to eq('Please provide an IP address as a query parameter.')
+    end
+  end
+
   describe 'with an invalid IP address' do
-    it 'returns an error' do
+    it 'returns a 400 error' do
       ipv6_address = 'FE80:CD00:0000:0CDE:1257:0000:211E:729C'
 
       get '/api/v1/locationByIp', params: { ip: ipv6_address }


### PR DESCRIPTION
This PR adds logic to the LocationbyIpController#validate_ip_address to handle when `params[:ip]` are `nil`.  An additional spec has been added as well.